### PR TITLE
Fix deserialization, theme and dialog style and bump version 1.0.3

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'com.android.library'
     id 'kotlin-parcelize'
     id 'kotlin-android'
+    id 'maven-publish'
 }
 
 group = PACKAGE

--- a/core/gradle.properties
+++ b/core/gradle.properties
@@ -1,3 +1,3 @@
 PACKAGE=com.parcelvoy.android
 ARTIFACT=android-sdk
-VERSION=1.0.2
+VERSION=1.0.3

--- a/core/src/main/java/com/parcelvoy/android/Models.kt
+++ b/core/src/main/java/com/parcelvoy/android/Models.kt
@@ -2,7 +2,9 @@ package com.parcelvoy.android
 
 import android.os.Build
 import android.os.Parcelable
+import com.google.gson.annotations.JsonAdapter
 import com.google.gson.annotations.SerializedName
+import com.parcelvoy.android.network.NotificationContentDeserializer
 import kotlinx.parcelize.Parcelize
 import org.json.JSONException
 import org.json.JSONObject
@@ -86,11 +88,13 @@ enum class NotificationType {
     HTML
 }
 
+@JsonAdapter(NotificationContentDeserializer::class)
 interface NotificationContent : Parcelable {
     val title: String
     val body: String
     val readOnShow: Boolean?
-    val custom: Map<String, String>?
+    val custom: Map<String, Any>?
+    val context: Map<String, String>?
 }
 
 @Parcelize
@@ -99,6 +103,7 @@ data class BannerNotification(
     override val body: String,
     override val readOnShow: Boolean? = null,
     override val custom: Map<String, String>? = null,
+    override val context: Map<String, String>? = null,
 ) : NotificationContent
 
 @Parcelize
@@ -108,6 +113,7 @@ data class AlertNotification(
     val image: String?,
     override val readOnShow: Boolean? = null,
     override val custom: Map<String, String>? = null,
+    override val context: Map<String, String>? = null,
 ) : NotificationContent
 
 @Parcelize
@@ -117,6 +123,7 @@ data class HtmlNotification(
     val html: String,
     override val readOnShow: Boolean? = null,
     override val custom: Map<String, String>? = null,
+    override val context: Map<String, String>? = null
 ) : NotificationContent
 
 @Parcelize

--- a/core/src/main/java/com/parcelvoy/android/Parcelvoy.kt
+++ b/core/src/main/java/com/parcelvoy/android/Parcelvoy.kt
@@ -256,6 +256,13 @@ open class Parcelvoy protected constructor(
             InAppDialogFragment.newInstance(
                 notification = notification,
                 delegate = object : InAppDelegate {
+
+                    override val autoShow: Boolean
+                        get() = inAppDelegate?.autoShow == true
+
+                    override val useDarkMode: Boolean
+                        get() = inAppDelegate?.useDarkMode == true
+
                     override fun handle(
                         action: InAppAction,
                         context: Map<String, Any>,

--- a/core/src/main/java/com/parcelvoy/android/network/NotificationContentDeserializer.kt
+++ b/core/src/main/java/com/parcelvoy/android/network/NotificationContentDeserializer.kt
@@ -1,0 +1,45 @@
+package com.parcelvoy.android.network
+
+import com.google.gson.JsonDeserializationContext
+import com.google.gson.JsonDeserializer
+import com.google.gson.JsonElement
+import com.google.gson.JsonObject
+import com.parcelvoy.android.AlertNotification
+import com.parcelvoy.android.BannerNotification
+import com.parcelvoy.android.HtmlNotification
+import com.parcelvoy.android.NotificationContent
+import java.lang.reflect.Type
+
+class NotificationContentDeserializer : JsonDeserializer<NotificationContent> {
+
+    companion object {
+        private const val KEY_CUSTOM = "custom"
+        private const val KEY_CONTEXT = "context"
+    }
+
+    override fun deserialize(
+        json: JsonElement,
+        typeOfT: Type,
+        context: JsonDeserializationContext
+    ): NotificationContent {
+        val contentJson = json.asJsonObject
+
+        val customJsonObject = contentJson.getAsJsonObject(KEY_CUSTOM)
+        var contextJsonObject: JsonObject? = null
+        if (customJsonObject != null && customJsonObject.has(KEY_CONTEXT)) {
+            contextJsonObject = customJsonObject.remove(KEY_CONTEXT)?.asJsonObject
+        }
+
+        if (contextJsonObject != null) {
+            contentJson.add(KEY_CONTEXT, contextJsonObject)
+        }
+
+        val concreteType: Class<out NotificationContent> = when {
+            contentJson.has("html") -> HtmlNotification::class.java
+            contentJson.has("image") -> AlertNotification::class.java
+            else -> BannerNotification::class.java
+        }
+
+        return context.deserialize(contentJson, concreteType)
+    }
+}

--- a/core/src/main/java/com/parcelvoy/android/network/ParcelvoyNotificationDeserializer.kt
+++ b/core/src/main/java/com/parcelvoy/android/network/ParcelvoyNotificationDeserializer.kt
@@ -29,11 +29,10 @@ class ParcelvoyNotificationDeserializer : JsonDeserializer<ParcelvoyNotification
         }
 
         val contentJson = jsonObject.getAsJsonObject("content")
-        val notificationContent: NotificationContent = when (contentType) {
-            NotificationType.BANNER -> context.deserialize(contentJson, BannerNotification::class.java)
-            NotificationType.ALERT -> context.deserialize(contentJson, AlertNotification::class.java)
-            NotificationType.HTML -> context.deserialize(contentJson, HtmlNotification::class.java)
-        }
+        val notificationContent: NotificationContent = context.deserialize(
+            contentJson,
+            NotificationContent::class.java
+        )
         return ParcelvoyNotification(
             id = jsonObject.get("id")?.asLong ?: 0L,
             contentType = contentType,

--- a/core/src/main/res/values/styles.xml
+++ b/core/src/main/res/values/styles.xml
@@ -1,8 +1,11 @@
 <resources>
 
     <style name="FullScreenDialogTheme" parent="@android:style/Theme.Translucent.NoTitleBar">
-        <item name="android:backgroundDimEnabled">false</item>
+        <item name="android:backgroundDimEnabled">false</item>\
+        <item name="android:windowIsFloating">false</item>
         <item name="android:windowTranslucentStatus">true</item>
+        <item name="android:windowDrawsSystemBarBackgrounds">true</item>
+        <item name="android:statusBarColor">@android:color/transparent</item>
+        <item name="android:navigationBarColor">@android:color/transparent</item>
     </style>
-
 </resources>


### PR DESCRIPTION
This PR:
- Bumps version 1.0.3
- Update dialog style to draw over the navigation buttons of device
- Update Notification Content deserilaziation to extract `context` object from `custom` map and put them at the same level.
- Fix InAppDelegate properties not being pass down to the InAppDialogFragment